### PR TITLE
Make qdecimal compile on Qt 5.9 with out-of-source builds

### DIFF
--- a/common.pri
+++ b/common.pri
@@ -9,7 +9,7 @@
 #CONFIG += debug
 
 
-if(win32) {
+win32 {
  INCLUDEPATH += .
  # Remove Qt's defaults
  QMAKE_CXXFLAGS -= -Zc:wchar_t-
@@ -28,7 +28,7 @@ if(win32) {
  }
 
 } # end win32
-else {
+else:equals(OUT_PWD, $$PWD) {
  MOC_DIR = moc
  OBJECTS_DIR = obj
 }

--- a/decnumber/decnumber.pro
+++ b/decnumber/decnumber.pro
@@ -10,7 +10,7 @@ TEMPLATE = lib
 CONFIG += static
 DEPENDPATH += .
 TARGET = decnumber
-DESTDIR = ../lib
+DESTDIR = $$OUT_PWD/../lib
 
 
 

--- a/src/QDecFwd.hh
+++ b/src/QDecFwd.hh
@@ -12,7 +12,7 @@
  *
  */
 
-#include <QtCore/QtGlobal>
+#include <QtGlobal>
 
 #ifndef DECNUMDIGITS
 //! Work with up to 80 digits as default, resulting in 64 bytes

--- a/src/src.pro
+++ b/src/src.pro
@@ -4,6 +4,7 @@
 include(../common.pri)
 
 QT -= gui
+QT += core
 TEMPLATE = lib
 
 # Pick if the library will be static or dynamic:
@@ -17,9 +18,9 @@ CONFIG += static
 TARGET = qdecimal
 DEPENDPATH += .
 # To include decnumber headers
-INCLUDEPATH += ../decnumber
-DESTDIR = ../lib
-LIBS += -L../lib -ldecnumber 
+INCLUDEPATH += $$PWD/../decnumber
+DESTDIR = $$OUT_PWD/../lib
+LIBS += -L$$OUT_PWD/../lib -ldecnumber 
 
 # Input
 HEADERS += QDecContext.hh \

--- a/test/Main.cc
+++ b/test/Main.cc
@@ -15,6 +15,7 @@
 void MessageOutput(QtMsgType type, const QMessageLogContext &context,
                      const QString &msg)
 {
+  Q_UNUSED(context)
   QByteArray lmsg = msg.toLocal8Bit();
   const char* cmsg = lmsg.constData();
   switch (type) {

--- a/test/Main.cc
+++ b/test/Main.cc
@@ -21,6 +21,11 @@ void MessageOutput(QtMsgType type, const QMessageLogContext &context,
     case QtDebugMsg:
       fprintf(stderr, "%s\n", cmsg);
       break;
+#if QT_VERSION >= QT_VERSION_CHECK(5, 5, 0)
+    case QtInfoMsg:
+      fprintf(stderr, "Info: %s\n", cmsg);
+      break;
+#endif
     case QtWarningMsg:
       fprintf(stderr, "Warn: %s\n", cmsg);
       break;

--- a/test/Main.cc
+++ b/test/Main.cc
@@ -1,4 +1,4 @@
-#include <QtTest/QtTest>
+#include <QtTest>
 
 #include "QDecNumberTests.hh"
 

--- a/test/test.pro
+++ b/test/test.pro
@@ -4,14 +4,15 @@
 include(../common.pri)
 
 QT -= gui
+QT += core
 TEMPLATE = app
 QT  += testlib 
 
 TARGET = qdecimal_test
-DESTDIR = ../bin
+DESTDIR = $$OUT_PWD/../bin
 DEPENDPATH += .
-INCLUDEPATH += ../decnumber ../src
-LIBS += -L../lib -lqdecimal -ldecnumber
+INCLUDEPATH += $$PWD/../decnumber $$PWD/../src
+LIBS += -L$${OUT_PWD}/../lib -lqdecimal -ldecnumber
 
 # Input
 HEADERS += QDecNumberTests.hh


### PR DESCRIPTION
Tested on OpenBSD 6.4/amd64-BETA, all tests pass.